### PR TITLE
feat: checkout com preço definido

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         minSdk = 26
         targetSdk = 36
         versionCode = 3
-        versionName = "1.1.0"
+        versionName = "1.1.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/br/com/brunocarvalhs/howmuch/app/modules/shoppingCart/ShoppingCartScreen.kt
+++ b/app/src/main/java/br/com/brunocarvalhs/howmuch/app/modules/shoppingCart/ShoppingCartScreen.kt
@@ -412,6 +412,7 @@ fun ShoppingCartContent(
 
     if (showFinalizeDialog) {
         FinalizePurchaseDialog(
+            totalPrice = uiState.totalPrice,
             onDismiss = {
                 setShowFinalizeDialog(false)
                 trackClick(

--- a/app/src/main/java/br/com/brunocarvalhs/howmuch/app/modules/shoppingCart/components/FinalizePurchaseDialog.kt
+++ b/app/src/main/java/br/com/brunocarvalhs/howmuch/app/modules/shoppingCart/components/FinalizePurchaseDialog.kt
@@ -9,6 +9,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -19,16 +20,16 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import br.com.brunocarvalhs.howmuch.R
-import br.com.brunocarvalhs.howmuch.app.foundation.constants.EMPTY_LONG
 import br.com.brunocarvalhs.howmuch.app.foundation.constants.EMPTY_STRING
 
 @Composable
 fun FinalizePurchaseDialog(
+    totalPrice: Long,
     onDismiss: () -> Unit,
     onSubmit: (name: String, price: Long) -> Unit
 ) {
     var name by remember { mutableStateOf(EMPTY_STRING) }
-    var price by remember { mutableLongStateOf(EMPTY_LONG) }
+    var price by remember { mutableLongStateOf(totalPrice) }
     var error by remember { mutableStateOf(false) }
 
     AlertDialog(

--- a/app/src/main/java/br/com/brunocarvalhs/howmuch/app/modules/shoppingCart/components/FinalizePurchaseDialog.kt
+++ b/app/src/main/java/br/com/brunocarvalhs/howmuch/app/modules/shoppingCart/components/FinalizePurchaseDialog.kt
@@ -9,7 +9,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf


### PR DESCRIPTION
O checkout de compra para finalizar o carrinho agora vem com o preço calculado pelo app, possibilitando edição caso venha mais ou menos o preço. 